### PR TITLE
fix requiring tail plugin

### DIFF
--- a/lib/fluent/plugin/in_tail_multiline_extended.rb
+++ b/lib/fluent/plugin/in_tail_multiline_extended.rb
@@ -1,3 +1,4 @@
+require 'fluent/plugin/in_tail'
 module Fluent
   class NewTailInput < Fluent::Plugin::TailInput
 


### PR DESCRIPTION
Since the plugin 'fluent/plugin/in_tail' is not being imported in class in_tail_multiline_extended.rb, it is breaking td-agent